### PR TITLE
Some typo fixes

### DIFF
--- a/events.json
+++ b/events.json
@@ -320,8 +320,8 @@
                 },
                 {
                     "title": "rtgame\nand tom",
-                    "subtitle": "city skylines",
-                    "extra": "sips, lewis,\npflax\nandrtgame",
+                    "subtitle": "cities skylines",
+                    "extra": "sips, lewis,\npflax\nand rtgame",
                     "subtitle2": "chilling",
                     "type": "yellow double split",
                     "startHour": 17
@@ -344,7 +344,7 @@
                 },
                 {
                     "title": "hoi bois",
-                    "subtitle": "isorrows, bo,\nrimmy, sips,\nlewis, pflax,\nand more!",
+                    "subtitle": "isorrow, bo,\nrimmy, sips,\nlewis, pflax,\nand more!",
                     "type": "pink double",
                     "startHour": 17
                 }
@@ -354,7 +354,7 @@
             "date": 12,
             "events": [
                 {
-                    "title": "isorrows\nmario party",
+                    "title": "isorrow\nmario party",
                     "type": "dark",
                     "startHour": 11
                 },


### PR DESCRIPTION
Hey! Really good thing you've put together, was interesting to see the code behind it. I noticed iSorrow's name was spelled as "iSorrows", and you've got a few other little typos that I fixed up.

I did also notice that several of these are lacking apostrophes where there should be (e.g., "Highrollers Honey Heist and Jason Statham's Vacation") and now I mention it some should probably have a colon (e.g., "Cities: Skylines" which is that game's proper title). I was wondering if you're intentionally avoiding apostrophes? If they are in fact safe to add, I'd be happy to submit another PR with them added where appropriate. It's a fussy thing I admit but if you'd like it I'd be happy to.

Thanks for making a useful tool!